### PR TITLE
Adjusted profile.py store serializer 

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -96,8 +96,8 @@ class Profile(ViewSet):
             current_user.recommends = Recommendation.objects.filter(recommender=current_user)
 
             try:
-                stores = Store.objects.filter(seller=request.auth.user)
-                store_data = StoreSerializer(stores, many=True, context={"request": request}).data
+                store = Store.objects.get(seller=request.auth.user)
+                store_data = StoreSerializer(store, many=False, context={"request": request}).data
 
             except Store.DoesNotExist:
                 store_data = None


### PR DESCRIPTION
Adjusted profile.py store serializer to only accept one store per profile and return as single iterable object instead of array. 



## Testing

Description of how to test code...

- [x] Run migrations
- [ ] Run test suite
- [x] Seed database


## Related Issues

- Fixes #51