### PR TITLE
Bb recent category items

### DIFF
--- a/bangazonapi/views/productcategory.py
+++ b/bangazonapi/views/productcategory.py
@@ -1,10 +1,3 @@
-"""
-   Author: Daniel Krusch
-   Purpose: To convert product category data to json
-   Methods: GET, POST
-"""
-
-"""View module for handling requests about product categories"""
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -58,9 +51,14 @@ class ProductCategories(ViewSet):
 
     def retrieve(self, request, pk=None):
         """Handle GET requests for single category"""
+        include_products = request.query_params.get('include_recent_products', None)
+            
         try:
             category = ProductCategory.objects.get(pk=pk)
-            serializer = ProductCategorySerializer(category, context={'request': request})
+            if include_products == 'true':
+                serializer = ProductCategoryWithRecentSerializer(category, context={'request': request})
+            else:
+                serializer = ProductCategorySerializer(category, context={'request': request})
             return Response(serializer.data)
         except Exception as ex:
             return HttpResponseServerError(ex)


### PR DESCRIPTION
Feature: Initial product view should list 5 most recently added items in each category
[#64](https://github.com/NSS-Day-Cohort-76/Bangazon-client-xvvkkq/issues/64)

Given a user has authenticated
When the product list should appear
Then a category header for each product category
And the five most recent products that have been added to the system should be listed under each header

Given the user is viewing the product list
When any filter is applied
Then the category headers will not be rendered
And any products that match the filter will be listed under a header labeled "Products matching filters"

2 Changes

- **productcategory.py:** added getProducts function that limits request to five results
- **productcategory.py:** updated logic
## Requests / Responses



